### PR TITLE
20251007-RHEL8V10

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ cd ../../wolfssl
 $ ./configure --enable-wolfguard --enable-cryptonly --enable-intelasm \
    --enable-linuxkm --with-linux-source=/usr/src/linux \
    --prefix=$(pwd)/linuxkm/build
-$ make -j
+$ make -j module
 # make install
 # modprobe libwolfssl
 ```
@@ -209,21 +209,25 @@ configured and built, and precisely match the kernel you will boot on your
 target system.
 
 This is a two-step process.  First you will build and install the module with an
-incorrect integrity hash.  Then you will load it to capture the correct hash
-(the instructions assume targeting the native system).  Then you will rebuild
-and load the module with the correct hash.  Note that the lowest libwolfssl FIPS
-version compatible with Linux kernel mode is `v5.2.4`.
+incorrect integrity hash.  Then you will load it to capture the correct hash,
+which will exit early with an expected “Operation canceled” error.  Then you
+will rebuild and load the module with the correct hash.  Note that thes
+instructions assume targeting the native system.  Note also that the lowest
+libwolfssl FIPS version compatible with Linux kernel mode is `v5.2.4`.
 ```
 $ cd ../../wolfssl
 $ ./configure --enable-fips=vX --enable-wolfguard --enable-cryptonly \
    --enable-linuxkm --with-linux-source=/usr/src/linux \
    --prefix=$(pwd)/linuxkm/build
-$ make -j
+$ make -j module
 # make install
 # modprobe libwolfssl
+```
+(Expect early exit of the above `modprobe`, with an “Operation canceled” message.)
+```
 $ NEWHASH=$(dmesg | awk '{if (match($0, " new hash \"([^\"]+)\" ", hash_a)) { hash = hash_a[1]; }} END {print hash}')
 $ sed --in-place=.bak "s/^\".*\";/\"${NEWHASH}\";/" wolfcrypt/src/fips_test.c
-$ make -j
+$ make -j module
 # make install
 # modprobe libwolfssl
 ```

--- a/kernel-src/compat/compat.h
+++ b/kernel-src/compat/compat.h
@@ -19,7 +19,9 @@
 #endif
 #elif RHEL_MAJOR == 8
 #define ISRHEL8
-#if RHEL_MINOR == 2
+#if RHEL_MINOR >= 10
+#define ISRHEL8V10P
+#elif RHEL_MINOR == 2
 #define ISCENTOS8
 #endif
 #endif
@@ -359,7 +361,7 @@ static inline bool rng_is_initialized(void)
 #define system_power_efficient_wq system_unbound_wq
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && !defined(ISRHEL8V10P)
 #include <linux/ktime.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0)
 #include <linux/hrtimer.h>
@@ -696,7 +698,7 @@ static inline void cpu_to_le32_array(u32 *buf, unsigned int words)
 #define hlist_add_behind(a, b) hlist_add_after(b, a)
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0) && !defined(ISRHEL8V10P)
 #define totalram_pages() totalram_pages
 #endif
 
@@ -788,7 +790,7 @@ static inline void skb_mark_not_on_list(struct sk_buff *skb)
 #endif
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0) && !defined(ISRHEL8V10P)
 #define genl_dumpit_info(cb) ({ \
 	struct { struct nlattr **attrs; } *a = (void *)((u8 *)cb->args + offsetofend(struct dump_ctx, next_allowedip)); \
 	BUILD_BUG_ON(sizeof(cb->args) < offsetofend(struct dump_ctx, next_allowedip) + sizeof(*a)); \

--- a/kernel-src/peer.c
+++ b/kernel-src/peer.c
@@ -65,7 +65,8 @@ struct wg_peer *wg_peer_create(struct wg_device *wg,
 	wg_noise_reset_last_sent_handshake(&peer->last_sent_handshake);
 	set_bit(NAPI_STATE_NO_BUSY_POLL, &peer->napi.state);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || \
-    (defined(RHEL_MAJOR) && ((RHEL_MAJOR > 9) || ((RHEL_MAJOR == 9) && (RHEL_MINOR >= 5))))
+    (defined(RHEL_MAJOR) && ((RHEL_MAJOR > 9) || ((RHEL_MAJOR == 9) && (RHEL_MINOR >= 5)))) || \
+    (defined(RHEL_MAJOR) && (((RHEL_MAJOR == 8) && (RHEL_MINOR >= 10))))
 	netif_napi_add_weight(wg->dev, &peer->napi, wg_packet_rx_poll,
 		       NAPI_POLL_WEIGHT);
 #else

--- a/kernel-src/queueing.h
+++ b/kernel-src/queueing.h
@@ -84,7 +84,8 @@ static inline void wg_reset_packet(struct sk_buff *skb, bool encapsulating)
 	skb_scrub_packet(skb, true);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)) || \
-    (defined(RHEL_MAJOR) && ((RHEL_MAJOR > 9) || ((RHEL_MAJOR == 9) && (RHEL_MINOR >= 5))))
+    (defined(RHEL_MAJOR) && ((RHEL_MAJOR > 9) || ((RHEL_MAJOR == 9) && (RHEL_MINOR >= 5)))) || \
+    (defined(RHEL_MAJOR) && (((RHEL_MAJOR == 8) && (RHEL_MINOR >= 10))))
 	memset(&skb->headers, 0,
                sizeof skb->headers);
 #else

--- a/kernel-src/ratelimiter.c
+++ b/kernel-src/ratelimiter.c
@@ -182,10 +182,20 @@ int wg_ratelimiter_init(void)
 	 * we borrow their wisdom about good table sizes on different systems
 	 * dependent on RAM. This calculation here comes from there.
 	 */
+#if defined(RHEL_MAJOR) && (RHEL_MAJOR == 8)
+        {
+            const unsigned long _roundup = roundup_pow_of_two(
+			(totalram_pages() << PAGE_SHIFT) /
+			(1U << 14) / sizeof(struct hlist_head));
+            table_size = (totalram_pages() > (1U << 30) / PAGE_SIZE) ? 8192 :
+                (_roundup > 16 ? _roundup : 16);
+        }
+#else
 	table_size = (totalram_pages() > (1U << 30) / PAGE_SIZE) ? 8192 :
 		max_t(unsigned long, 16, roundup_pow_of_two(
 			(totalram_pages() << PAGE_SHIFT) /
 			(1U << 14) / sizeof(struct hlist_head)));
+#endif
 	max_entries = table_size * 8;
 
 	table_v4 = kvzalloc(table_size * sizeof(*table_v4), GFP_KERNEL);

--- a/kernel-src/wolfcrypt_glue.c
+++ b/kernel-src/wolfcrypt_glue.c
@@ -388,9 +388,12 @@ static __always_inline bool wc_AesGcm_crypt_sg_inplace(struct scatterlist *src, 
         }
 
         sg_miter_stop(&miter);
+
+        goto out;
     }
-    else {
+
     copy_after_all:
+    {
         byte *buf = (byte *)XMALLOC(src_len + WC_AES_BLOCK_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
         if (! buf) {


### PR DESCRIPTION
portability fixes for RHEL 8.10

tested with `linuxkm-fips-dev-insmod-wolfguard` and `linuxkm-fips-v5-vanilla-insmod-wolfguard-cust-kernel-3`.
