### PR TITLE
20260203-backport-DEBUG_RATELIMITER_TIMINGS

### DIFF
--- a/kernel-src/selftest/ratelimiter.c
+++ b/kernel-src/selftest/ratelimiter.c
@@ -167,7 +167,7 @@ bool __init wg_ratelimiter_selftest(void)
 	++test;
 #endif
 
-	for (trials = TRIALS_BEFORE_GIVING_UP;;) {
+	for (trials = TRIALS_BEFORE_GIVING_UP; IS_ENABLED(DEBUG_RATELIMITER_TIMINGS);) {
 		int test_count = 0, ret;
 
 		ret = timings_test(skb4, hdr4, skb6, hdr6, &test_count);


### PR DESCRIPTION
`kernel-src/selftest/ratelimiter.c`: backport torvalds/linux@684dec3cf4 "wireguard: ratelimiter: disable timings test by default".

detected and tested with
```
WOLFGUARD_BRANCH=20260203-backport-DEBUG_RATELIMITER_TIMINGS wolfssl-multi-test.sh ...
linuxkm-legacy-6.12-insmod-fips
```
