### PR TITLE
fix: dkms.conf WOLFSSL_ROOT passthrough and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,3 +306,27 @@ exported with exactly 44 characters of base64.  WolfGuard public keys are
 roughly twice that length, unless built with `WG_USE_PUBLIC_KEY_COMPRESSION`,
 which is not currently supported in FIPS v5, but is supported in FIPS v6 and
 later.
+
+
+### Using DKMS for automatic kernel module rebuilds
+
+DKMS (Dynamic Kernel Module Support) automatically rebuilds `wolfguard.ko`
+whenever a new kernel is installed, which is useful on systems with frequent
+kernel updates (e.g. Ubuntu with `unattended-upgrades`).
+
+Before registering wolfguard with DKMS, the built wolfssl source tree must be
+accessible at `/usr/src/wolfssl`.  Create a symlink if your wolfssl tree is
+elsewhere:
+```
+# ln -s /path/to/your/wolfssl /usr/src/wolfssl
+```
+If you prefer not to use `/usr/src/wolfssl`, set `WOLFSSL_ROOT` in the
+environment before running `dkms install` and it will be passed through to the
+build.
+
+Register and install the module (replace `<version>` with the value of
+`PACKAGE_VERSION` in `kernel-src/dkms.conf`):
+```
+# dkms add /path/to/wolfguard/kernel-src
+# dkms install wolfguard/<version>
+```

--- a/kernel-src/dkms.conf
+++ b/kernel-src/dkms.conf
@@ -5,7 +5,7 @@ AUTOINSTALL=yes
 BUILT_MODULE_NAME="wolfguard"
 DEST_MODULE_LOCATION="/wolfssl"
 
-MAKE="make -j WOLFSSL_ROOT=${WOLFSSL_ROOT:-/usr/src/wolfssl} module"
+MAKE="make -j WOLFSSL_ROOT='${WOLFSSL_ROOT:-/usr/src/wolfssl}' module"
 
-# requires kernel 3.10 - 8.x, inclusive:
-BUILD_EXCLUSIVE_KERNEL="^(([87654]\.)|(3\.1[0-9]))"
+# requires kernel 3.10 - 7.x, inclusive:
+BUILD_EXCLUSIVE_KERNEL="^(([7654]\.)|(3\.1[0-9]\.))"

--- a/kernel-src/dkms.conf
+++ b/kernel-src/dkms.conf
@@ -5,7 +5,7 @@ AUTOINSTALL=yes
 BUILT_MODULE_NAME="wolfguard"
 DEST_MODULE_LOCATION="/wolfssl"
 
-MAKE="make -j module"
+MAKE="make -j WOLFSSL_ROOT=${WOLFSSL_ROOT:-/usr/src/wolfssl} module"
 
-# requires kernel 3.10 - 7.x, inclusive:
-BUILD_EXCLUSIVE_KERNEL="^(([7654]\.)|(3\.1[0-9]))"
+# requires kernel 3.10 - 8.x, inclusive:
+BUILD_EXCLUSIVE_KERNEL="^(([87654]\.)|(3\.1[0-9]))"


### PR DESCRIPTION
## Summary

- `dkms.conf` `MAKE` command never passed `WOLFSSL_ROOT`, so DKMS builds always failed at link time. Now defaults to `/usr/src/wolfssl`; overridable via environment variable.
- `BUILD_EXCLUSIVE_KERNEL` regex only matched kernels 3–7; extended to include 8.x.
- Added a DKMS usage section to `README.md` documenting the `/usr/src/wolfssl` convention and the `WOLFSSL_ROOT` override.

## Test plan

- [ ] `dkms add kernel-src/` with wolfssl at `/usr/src/wolfssl` — verify build succeeds
- [ ] `WOLFSSL_ROOT=/custom/path dkms install wolfguard/<version>` — verify override is respected
- [ ] Confirm `dkms status` reports module installed on a kernel 8.x system