### PR TITLE
fix: document FIPS v5 reseed suppression and genkey privilege requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ under `/lib/modules/` where the target kernel's modules are installed.
 The `genkey` and `pubkey` ops in the final line are basic functionality tests.
 If all is well, it will succeed, and print a random public key.
 
+**Note:** When the `wolfguard.ko` kernel module is loaded, `wg genkey` (and
+`wg-fips genkey`) offloads key generation to the kernel module via netlink and
+therefore requires `CAP_NET_ADMIN`.  Non-root users will receive a permission
+error.  To resolve this, either run as root or via `sudo`, or build `wg-fips`
+with `NO_IPC_LLCRYPTO=1` (which selects the userspace key generation path), or
+grant the `wg-fips` binary the `cap_net_admin` file capability
+(`setcap cap_net_admin+ep wg-fips`).
+
 As for the `wg-fips` build above, compressed public key support can be enabled
 by adding `EXTRA_CFLAGS=-DWG_USE_PUBLIC_KEY_COMPRESSION` to the above `make`
 recipe.  The `WG_USE_PUBLIC_KEY_COMPRESSION` setting must be matched throughout
@@ -295,6 +303,14 @@ $ ../user-src/wg-fips genkey | ../user-src/wg-fips pubkey
 
 The `genkey` and `pubkey` ops in the final line are basic functionality tests.
 If all is well, it will succeed, and print a random public key.
+
+**Note:** When the `wolfguard.ko` kernel module is loaded, `wg genkey` (and
+`wg-fips genkey`) offloads key generation to the kernel module via netlink and
+therefore requires `CAP_NET_ADMIN`.  Non-root users will receive a permission
+error.  To resolve this, either run as root or via `sudo`, or build `wg-fips`
+with `NO_IPC_LLCRYPTO=1` (which selects the userspace key generation path), or
+grant the `wg-fips` binary the `cap_net_admin` file capability
+(`setcap cap_net_admin+ep wg-fips`).
 
 As with the non-FIPS-certified procedure, if all of the above succeeds, then you
 are now ready to bring up WolfGuard tunnels.  Existing playbooks and scripting

--- a/kernel-src/netlink.c
+++ b/kernel-src/netlink.c
@@ -876,6 +876,13 @@ struct genl_ops genl_ops[] = {
 #endif
 		.flags = GENL_UNS_ADMIN_PERM
 	}, {
+		/* Key generation is offloaded to the kernel module and
+		 * therefore requires CAP_NET_ADMIN.  Users without this
+		 * privilege should either run via sudo/root, or build
+		 * with NO_IPC_LLCRYPTO=1 to use the userspace key
+		 * generation path, or ensure the wg-fips binary has the
+		 * appropriate file capabilities set (e.g. cap_net_admin+ep).
+		 */
 		.cmd = WG_CMD_GEN_PRIVKEY,
 		.doit = wg_nl_generate_privkey,
 		.policy = device_policy,

--- a/kernel-src/wolfcrypt_glue.c
+++ b/kernel-src/wolfcrypt_glue.c
@@ -1196,6 +1196,10 @@ int wc_linuxkm_drbg_generate(struct wc_linuxkm_drbg_ctx *ctx,
 retry:
 
 #if defined(HAVE_FIPS) && FIPS_VERSION_LT(6,0)
+    /* FIPS v5 does not expose an API to externally reseed the DRBG.
+     * The entropy input is therefore discarded here.  The DRBG output
+     * remains safe: it was properly seeded at initialization time.
+     */
     (void)src;
     (void)slen;
 #else


### PR DESCRIPTION
## Summary

Two comment/documentation fixes:

### Fix 1: FIPS v5 reseed suppression (kernel-src/wolfcrypt_glue.c)

In `wc_linuxkm_drbg_generate()`, the `#if defined(HAVE_FIPS) && FIPS_VERSION_LT(6,0)` block silently discards the `src`/`slen` entropy input with bare `(void)` suppressors.  This is correct behavior — FIPS v5 does not expose an external reseed API — but it was unexplained, making the code appear to be a stub or oversight.

Added a concise comment explaining:
- FIPS v5 does not expose an API to externally reseed the DRBG
- The entropy input is therefore discarded
- The DRBG output remains safe because it was properly seeded at initialization

### Fix 2: `wg genkey` requires CAP_NET_ADMIN when kernel module is loaded

When `wolfguard.ko` is loaded, `wg genkey` / `wg-fips genkey` offloads key generation to the kernel module via Generic Netlink (`WG_CMD_GEN_PRIVKEY`).  That operation is gated by `GENL_UNS_ADMIN_PERM`, which requires `CAP_NET_ADMIN`.  This surprised users who expected `genkey` to be an unprivileged operation (as it is in upstream WireGuard).

**Part A** (`kernel-src/netlink.c`): Added a comment on the `WG_CMD_GEN_PRIVKEY` ops entry explaining the privilege requirement and the available remedies (sudo/root, `NO_IPC_LLCRYPTO=1` build, or `setcap cap_net_admin+ep`).

**Part B** (`README.md`): Added a note in both the non-FIPS and FIPS build/install procedures, immediately after the `wg-fips genkey | wg-fips pubkey` smoke-test lines, explaining the `CAP_NET_ADMIN` requirement and the three remedies.

## No code changes

This PR is comments and documentation only.  No logic, no API, no behavior was changed.