### PR TITLE
fix: correct u64 error sentinel width and XMALLOC/XFREE pairing

### DIFF
--- a/kernel-src/wolfcrypt_glue.c
+++ b/kernel-src/wolfcrypt_glue.c
@@ -312,7 +312,7 @@ static __always_inline bool wc_AesGcm_crypt_sg_inplace(struct scatterlist *src, 
     if (miter_needs_stop)
         sg_miter_stop(&miter);
 
-    free(aes);
+    XFREE(aes, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     WC_DEBUG_PR_IF_NEG(ret);
 
@@ -447,7 +447,7 @@ static __always_inline bool wc_AesGcm_crypt_sg_inplace(struct scatterlist *src, 
             else
                 wc_ForceZero(buf, src_len + WC_AES_BLOCK_SIZE);
         }
-        free(buf);
+        XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 
   out:
@@ -456,7 +456,7 @@ static __always_inline bool wc_AesGcm_crypt_sg_inplace(struct scatterlist *src, 
 
   out_aes_uninited:
 
-    free(aes);
+    XFREE(aes, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     wc_ForceZero(full_nonce, sizeof full_nonce);
 

--- a/kernel-src/wolfcrypt_glue.h
+++ b/kernel-src/wolfcrypt_glue.h
@@ -145,7 +145,7 @@ static inline int wc_sha256_oneshot2(byte *out, const byte *message1, const size
 static inline u64 wc_u64_keyed_hash(const byte *key, const size_t key_len, const byte *message, const size_t message_len) {
     u64 ret[WC_SHA256_DIGEST_SIZE / sizeof(u64)];
     if (wc_sha256_oneshot2((byte *)ret, key, key_len, message, message_len) < 0)
-        return ~0UL;
+        return ~(u64)0;
     else
         return ret[0];
 }


### PR DESCRIPTION
## Summary

Two independent correctness fixes in the kernel-side wolfcrypt glue code.

### Fix 1: Correct u64 error sentinel width in `wc_u64_keyed_hash` (wolfcrypt_glue.h)

`wc_u64_keyed_hash` returns `~0UL` as the error sentinel for a `u64` return type. On 32-bit kernels, `unsigned long` is 32 bits, so `~0UL` evaluates to `0xFFFFFFFF`, which zero-extends to `0x00000000FFFFFFFF` in the `u64` return — not the intended all-ones pattern `0xFFFFFFFFFFFFFFFF`.

The fix changes the sentinel to `~(u64)0`, which is always 64 bits wide regardless of the native `unsigned long` size.

This bug is latent on all current 64-bit targets (where `UL` happens to be 64 bits), but the correct form is required for portability to 32-bit kernels and for clarity of intent.

### Fix 2: Replace `free()` with `XFREE()` for XMALLOC-allocated buffers (wolfcrypt_glue.c)

In `wc_AesGcm_crypt_sg_inplace` (both the `WOLFSSL_AESGCM_STREAM` and non-stream variants), memory allocated with `XMALLOC(..., NULL, DYNAMIC_TYPE_TMP_BUFFER)` was being released with plain `free()`:

- `aes` pointer in the `WOLFSSL_AESGCM_STREAM` path (`out_aes_uninited` label)
- `buf` pointer in the non-stream `copy_after_all` block
- `aes` pointer in the non-stream path (`out_aes_uninited` label)

All three are replaced with `XFREE(ptr, NULL, DYNAMIC_TYPE_TMP_BUFFER)` to match the allocator.

Under `WOLFSSL_TRACK_MEMORY` builds, `XMALLOC` routes through a tracking wrapper. Releasing such memory with `free()` bypasses the tracker, causing spurious leak reports and potentially corrupting the tracking state. This bug is latent until `WOLFSSL_TRACK_MEMORY` is enabled.

Note: other `free()` calls in the same file (for `wc_hmac`, `aes` in `wc_AesGcm_oneshot_crypt`, `key`, `privKey`, `pubKey`, `ctx->rngs`) were all allocated with plain `malloc()` and are correctly paired — those were not changed.