### PR TITLE
fix: validate key lengths from kernel reply and fix try_again loop cleanup

### DIFF
--- a/user-src/ipc-linux.h
+++ b/user-src/ipc-linux.h
@@ -540,20 +540,24 @@ static int parse_privkey(const struct nlattr *attr, void *data)
 
 	switch (mnl_attr_get_type(attr)) {
 	case WGDEVICE_A_PRIVATE_KEY:
-		*privkey->privkey_len = mnl_attr_get_payload_len(attr);
-		*privkey->privkey = malloc(*privkey->privkey_len);
+		if (mnl_attr_get_payload_len(attr) != WG_PRIVATE_KEY_LEN)
+			return MNL_CB_ERROR;
+		*privkey->privkey_len = WG_PRIVATE_KEY_LEN;
+		*privkey->privkey = malloc(WG_PRIVATE_KEY_LEN);
 		if (! *privkey->privkey)
 			return MNL_CB_ERROR;
-		memcpy(*privkey->privkey, mnl_attr_get_payload(attr), *privkey->privkey_len);
+		memcpy(*privkey->privkey, mnl_attr_get_payload(attr), WG_PRIVATE_KEY_LEN);
 		break;
 	case WGDEVICE_A_PUBLIC_KEY:
 		if (! privkey->pubkey)
 			return MNL_CB_OK;
-		*privkey->pubkey_len = mnl_attr_get_payload_len(attr);
-		*privkey->pubkey = malloc(*privkey->pubkey_len);
+		if (mnl_attr_get_payload_len(attr) != WG_PUBLIC_KEY_LEN)
+			return MNL_CB_ERROR;
+		*privkey->pubkey_len = WG_PUBLIC_KEY_LEN;
+		*privkey->pubkey = malloc(WG_PUBLIC_KEY_LEN);
 		if (! *privkey->pubkey)
 			return MNL_CB_ERROR;
-		memcpy(*privkey->pubkey, mnl_attr_get_payload(attr), *privkey->pubkey_len);
+		memcpy(*privkey->pubkey, mnl_attr_get_payload(attr), WG_PUBLIC_KEY_LEN);
 		break;
 	}
 
@@ -605,8 +609,10 @@ try_again:
 	}
 
 out:
-	if (nlg)
+	if (nlg) {
 		mnlg_socket_close(nlg);
+		nlg = NULL;
+	}
 	if (ret) {
 		if (*privkey) {
 			memzero_explicit(*privkey, *privkey_len);
@@ -641,11 +647,13 @@ static int parse_pubkey(const struct nlattr *attr, void *data)
 	case WGDEVICE_A_PUBLIC_KEY:
 		if (! pubkey->pubkey)
 			return MNL_CB_OK;
-		*pubkey->pubkey_len = mnl_attr_get_payload_len(attr);
-		*pubkey->pubkey = malloc(*pubkey->pubkey_len);
+		if (mnl_attr_get_payload_len(attr) != WG_PUBLIC_KEY_LEN)
+			return MNL_CB_ERROR;
+		*pubkey->pubkey_len = WG_PUBLIC_KEY_LEN;
+		*pubkey->pubkey = malloc(WG_PUBLIC_KEY_LEN);
 		if (! *pubkey->pubkey)
 			return MNL_CB_ERROR;
-		memcpy(*pubkey->pubkey, mnl_attr_get_payload(attr), *pubkey->pubkey_len);
+		memcpy(*pubkey->pubkey, mnl_attr_get_payload(attr), WG_PUBLIC_KEY_LEN);
 		break;
 	}
 
@@ -691,8 +699,10 @@ try_again:
 	}
 
 out:
-	if (nlg)
+	if (nlg) {
 		mnlg_socket_close(nlg);
+		nlg = NULL;
+	}
 	if (ret) {
 		if (*pubkey) {
 			free(*pubkey);
@@ -717,11 +727,13 @@ static int parse_psk(const struct nlattr *attr, void *data)
 
 	switch (mnl_attr_get_type(attr)) {
 	case WGDEVICE_A_PRESHARED_KEY:
-		*psk->psk_len = mnl_attr_get_payload_len(attr);
-		*psk->psk = malloc(*psk->psk_len);
+		if (mnl_attr_get_payload_len(attr) != WG_SYMMETRIC_KEY_LEN)
+			return MNL_CB_ERROR;
+		*psk->psk_len = WG_SYMMETRIC_KEY_LEN;
+		*psk->psk = malloc(WG_SYMMETRIC_KEY_LEN);
 		if (! *psk->psk)
 			return MNL_CB_ERROR;
-		memcpy(*psk->psk, mnl_attr_get_payload(attr), *psk->psk_len);
+		memcpy(*psk->psk, mnl_attr_get_payload(attr), WG_SYMMETRIC_KEY_LEN);
 		break;
 	}
 
@@ -766,8 +778,10 @@ try_again:
 	}
 
 out:
-	if (nlg)
+	if (nlg) {
 		mnlg_socket_close(nlg);
+		nlg = NULL;
+	}
 	if (ret) {
 		if (*psk) {
 			memzero_explicit(*psk, *psk_len);


### PR DESCRIPTION
## Summary

Two correctness fixes in `user-src/ipc-linux.h` for the wolfguard userspace IPC code.

### Fix 1: Key length validation in parse_privkey, parse_pubkey, parse_psk

`parse_privkey`, `parse_pubkey`, and `parse_psk` previously used `mnl_attr_get_payload_len(attr)` as both the allocation size and the copy length, with no check against the expected key size. A kernel response with the wrong payload length would be silently accepted, allocating and storing a buffer of the wrong size.

The fix adds a length check against `WG_PRIVATE_KEY_LEN`, `WG_PUBLIC_KEY_LEN`, and `WG_SYMMETRIC_KEY_LEN` respectively before allocating. On mismatch, the callback returns `MNL_CB_ERROR` rather than allocating, matching the error-handling pattern used in `parse_allowedips`. The existing `parse_device` and `parse_peer` callbacks already applied this pattern (inline length checks before memcpy); this brings the genkey-specific parsers into conformance.

### Fix 2: nlg = NULL after mnlg_socket_close in try_again loops

`kernel_generate_privkey`, `kernel_derive_pubkey`, and `kernel_generate_psk` each have a `try_again` loop. In the `out:` cleanup block, `mnlg_socket_close(nlg)` was called but `nlg` was not set to `NULL` afterward. On a `goto try_again`, the stale (closed/freed) socket pointer remained in `nlg`. If `mnlg_socket_open` subsequently fails on the retry, the function returns early — but the `out:` block's `if (nlg)` guard is misleading: `nlg` is non-NULL but invalid.

The fix adds `nlg = NULL` immediately after `mnlg_socket_close(nlg)` in each `out:` block, making the cleanup safe regardless of retry behavior and matching defensive coding conventions.

## Files changed

- `user-src/ipc-linux.h`: All changes are confined to the `#ifndef NO_IPC_LLCRYPTO` section (parse callbacks and genkey/pubkey/psk kernel IPC functions).