### PR TITLE
20260427-null-after-free

### DIFF
--- a/kernel-src/device.c
+++ b/kernel-src/device.c
@@ -471,12 +471,15 @@ err_free_incoming_handshakes:
 err_free_tstats:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
 	free_percpu(dev->tstats);
+	dev->tstats = NULL;
 err_free_index_hashtable:
 #endif
 	kvfree(wg->index_hashtable);
+	wg->index_hashtable = NULL;
 err_free_peer_hashtable:
-        memzero_explicit(wg->peer_hashtable->key, sizeof wg->peer_hashtable->key);
+	memzero_explicit(wg->peer_hashtable->key, sizeof wg->peer_hashtable->key);
 	kvfree(wg->peer_hashtable);
+	wg->peer_hashtable = NULL;
 	WC_DEBUG_PR_NEG_RET(ret);
 }
 

--- a/kernel-src/ratelimiter.c
+++ b/kernel-src/ratelimiter.c
@@ -258,8 +258,10 @@ void wg_ratelimiter_uninit(void)
 	rcu_barrier();
 	memzero_explicit(key, sizeof key);
 	kvfree(table_v4);
+	table_v4 = NULL;
 #if IS_ENABLED(CONFIG_IPV6)
 	kvfree(table_v6);
+	table_v6 = NULL;
 #endif
 	kmem_cache_destroy(entry_cache);
 out:


### PR DESCRIPTION
`kernel-src/ratelimiter.c`: null out `table_v4` and `table_v6` after free in `wg_ratelimiter_uninit()` (fixes F-3354);

`kernel-src/device.c`: null out `dev->tstats`, `wg->index_hashtable`, and `wg->peer_hashtable` after free in `wg_newlink()` error paths.

tested with `wolfssl-multi-test.sh` ... `quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-mainline-insmod`.
