### PR TITLE
20260513-fixes

### DIFF
--- a/kernel-src/device.c
+++ b/kernel-src/device.c
@@ -276,6 +276,7 @@ static void wg_destruct(struct net_device *dev)
 	rcu_barrier(); /* Wait for all the peers to be actually freed. */
 	wg_ratelimiter_uninit();
 	memzero_explicit(&wg->static_identity, sizeof(wg->static_identity));
+	memzero_explicit(&wg->cookie_checker.secret, sizeof(wg->cookie_checker.secret));
 	skb_queue_purge(&wg->incoming_handshakes);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
 	free_percpu(dev->tstats);
@@ -477,6 +478,7 @@ err_free_index_hashtable:
 	kvfree(wg->index_hashtable);
 	wg->index_hashtable = NULL;
 err_free_peer_hashtable:
+	memzero_explicit(&wg->cookie_checker.secret, sizeof(wg->cookie_checker.secret));
 	memzero_explicit(wg->peer_hashtable->key, sizeof wg->peer_hashtable->key);
 	kvfree(wg->peer_hashtable);
 	wg->peer_hashtable = NULL;

--- a/kernel-src/netlink.c
+++ b/kernel-src/netlink.c
@@ -559,7 +559,8 @@ static int wg_set_device(struct sk_buff *skb, struct genl_info *info)
 		u8 public_key[NOISE_PUBLIC_KEY_LEN];
 		struct wg_peer *peer, *temp;
 
-		if (!ConstantCompare(wg->static_identity.static_private,
+		if (wg->static_identity.has_identity &&
+		    !ConstantCompare(wg->static_identity.static_private,
 				     private_key, NOISE_PRIVATE_KEY_LEN))
 			goto skip_set_private_key;
 

--- a/kernel-src/noise.c
+++ b/kernel-src/noise.c
@@ -327,13 +327,18 @@ void wg_noise_set_static_identity_private_key(
 	struct noise_static_identity *static_identity,
 	const u8 private_key[NOISE_PRIVATE_KEY_LEN])
 {
-	memcpy(static_identity->static_private, private_key,
-	       NOISE_PRIVATE_KEY_LEN);
-
-	static_identity->has_identity = wc_ecc_private_to_public_exim(
-		static_identity->static_private, sizeof(static_identity->static_private),
-		static_identity->static_public, sizeof(static_identity->static_public),
-		NOISE_CURVE_ID, WG_PUBLIC_KEY_COMPRESSED) == 0;
+	if (wc_ecc_private_to_public_exim(private_key, NOISE_PRIVATE_KEY_LEN,
+					  static_identity->static_public,
+					  sizeof(static_identity->static_public),
+					  NOISE_CURVE_ID, WG_PUBLIC_KEY_COMPRESSED)
+	    == 0)
+	{
+		memcpy(static_identity->static_private, private_key,
+		       NOISE_PRIVATE_KEY_LEN);
+		static_identity->has_identity = 1;
+	}
+	else
+		static_identity->has_identity = 0;
 }
 
 /* This is Hugo Krawczyk's HKDF:

--- a/kernel-src/peer.c
+++ b/kernel-src/peer.c
@@ -88,7 +88,10 @@ err_3:
 err_2:
 	dst_cache_destroy(&peer->endpoint_cache);
 err_1:
-	kfree(peer);
+	/* use kfree_sensitive() to clean up peer->handshake.preshared_key and
+	 * peer->handshake.precomputed_static_static.
+	 */
+	kfree_sensitive(peer);
 	return ERR_PTR(ret);
 }
 

--- a/kernel-src/selftest/allowedips.c
+++ b/kernel-src/selftest/allowedips.c
@@ -324,7 +324,7 @@ static __init bool randomized_test(void)
 				mutate_mask[k] = 0xff;
 			mutate_mask[k] = 0xff
 					 << ((8 - (mutate_amount % 8)) % 8);
-			for (; k < 4; ++k)
+			for (k = mutate_amount/8 + 1; k < 4; ++k)
 				mutate_mask[k] = 0;
 			for (k = 0; k < 4; ++k)
 				mutated[k] = (mutated[k] & mutate_mask[k]) |

--- a/user-src/pubkey.c
+++ b/user-src/pubkey.c
@@ -63,11 +63,13 @@ int pubkey_main(int argc, char *argv[])
 	pubkey_base64 = (char *)malloc(pubkey_base64_len);
 	if (! pubkey_base64) {
 		fprintf(stderr, "malloc: %m\n");
+		ret = -ENOMEM;
 		goto out;
 	}
 
 	if (!wg_to_base64(pubkey_base64, pubkey_base64_len, pubkey, pubkey_len)) {
 		fprintf(stderr, "wg_to_base64() failed.\n");
+		ret = -EINVAL;
 		goto out;
 	}
 
@@ -121,6 +123,7 @@ int pubkey_main(int argc, char *argv[])
 
 	if (fread(base64, 1, WG_BASE64_LEN(WG_PRIVATE_KEY_LEN) - 1, stdin) != WG_BASE64_LEN(WG_PRIVATE_KEY_LEN) - 1) {
 		errno = EINVAL;
+		ret = -EINVAL;
 		fprintf(stderr, "%s: Key is not the correct length or format\n", PROG_NAME);
 		goto out;
 	}
@@ -133,11 +136,13 @@ int pubkey_main(int argc, char *argv[])
 		if (trailing_char == EOF)
 			break;
 		fprintf(stderr, "%s: Trailing characters found after key\n", PROG_NAME);
+		ret = -EINVAL;
 		goto out;
 	}
 
 	if (!wg_from_base64(key, WG_PRIVATE_KEY_LEN, base64, WG_BASE64_LEN(WG_PRIVATE_KEY_LEN) - 1)) {
 		fprintf(stderr, "%s: wg_from_base64(): Key is not the correct length or format\n", PROG_NAME);
+		ret = -EINVAL;
 		goto out;
 	}
 


### PR DESCRIPTION
Fixes for F-3100 F3101 F-3097 F-3355 F-3796 F-3797 F-3798.

tested with
```
WOLFGUARD_BRANCH=local:20260513-fixes wolfssl-multi-test.sh ...
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-ksan-wolfguard
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-kmemleak-wolfguard
linuxkm-fips-dev-insmod-cust-kernel-3-with-wolfguard
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-linuxkm-mainline-clang-tidy
quantum-safe-wolfssl-all-crypto-only-intelasm-sp-asm-fips-dev-linuxkm-next-clang-tidy
```
