### PR TITLE
20260526-fixes

### DIFF
--- a/kernel-src/device.c
+++ b/kernel-src/device.c
@@ -26,6 +26,7 @@
 #include <linux/if_arp.h>
 #include <linux/icmp.h>
 #include <linux/suspend.h>
+#include <linux/ctype.h>
 #include <net/icmp.h>
 #include <net/rtnetlink.h>
 #include <net/ip_tunnels.h>
@@ -341,6 +342,23 @@ static void wg_setup(struct net_device *dev)
 	wg->dev = dev;
 }
 
+static bool wg_link_dev_name_valid(const struct net_device *dev)
+{
+	const unsigned char *n;
+
+	/* Allow only printable ASCII characters in device names -- other
+	 * characters can confuse log rendering, particularly when ANSI
+	 * sequences are interpreted.
+	 *
+	 * Note that net admins can rename devices after initialization,
+	 * bypassing this test.
+	 */
+	for (n = (const unsigned char *)dev->name; *n; ++n)
+		if (!isprint(*n))
+			return false;
+	return true;
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
 static int wg_newlink(struct net_device *dev,
 		      struct rtnl_newlink_params *params,
@@ -358,6 +376,9 @@ static int wg_newlink(struct net *src_net, struct net_device *dev,
 	int ret;
 
 	(void)extack;
+
+	if (!wg_link_dev_name_valid(dev))
+		WC_DEBUG_PR_NEG_RET(-EINVAL);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
 	rcu_assign_pointer(wg->creating_net, link_net);

--- a/kernel-src/device.c
+++ b/kernel-src/device.c
@@ -373,7 +373,7 @@ static int wg_newlink(struct net *src_net, struct net_device *dev,
 	wg_allowedips_init(&wg->peer_allowedips);
 	ret = wg_cookie_checker_init(&wg->cookie_checker, wg);
 	if (ret)
-		WC_DEBUG_PR_NEG_RET(ret);
+		goto err_zero_cookie_checker_secret;
 
 	ret = -ENOMEM;
 
@@ -382,7 +382,7 @@ static int wg_newlink(struct net *src_net, struct net_device *dev,
 
 	wg->peer_hashtable = wg_pubkey_hashtable_alloc();
 	if (!wg->peer_hashtable)
-		WC_DEBUG_PR_NEG_RET(ret);
+		goto err_zero_cookie_checker_secret;
 
 	wg->index_hashtable = wg_index_hashtable_alloc();
 	if (!wg->index_hashtable)
@@ -478,10 +478,11 @@ err_free_index_hashtable:
 	kvfree(wg->index_hashtable);
 	wg->index_hashtable = NULL;
 err_free_peer_hashtable:
-	memzero_explicit(&wg->cookie_checker.secret, sizeof(wg->cookie_checker.secret));
 	memzero_explicit(wg->peer_hashtable->key, sizeof wg->peer_hashtable->key);
 	kvfree(wg->peer_hashtable);
 	wg->peer_hashtable = NULL;
+err_zero_cookie_checker_secret:
+	memzero_explicit(&wg->cookie_checker.secret, sizeof(wg->cookie_checker.secret));
 	WC_DEBUG_PR_NEG_RET(ret);
 }
 

--- a/kernel-src/noise.c
+++ b/kernel-src/noise.c
@@ -721,20 +721,26 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 		goto out;
 	}
 
-	down_read(&handshake->lock);
+        /* Get an exclusive lock here, even though initially we only need a read
+	 * lock -- this avoids a race window after the defensive tests and
+	 * before storing the new ephemeral key.  The attack tests have a
+	 * negligible CPU footprint, so the atomic ops (identically expensive
+	 * for exclusive and shared) dominate here, militating for a single
+	 * semaphore cycle with exclusive semantics.
+	 */
+	down_write(&handshake->lock);
 	replay_attack = memcmp(t, handshake->latest_timestamp,
 			       NOISE_TIMESTAMP_LEN) <= 0;
 	flood_attack = (s64)handshake->last_initiation_consumption +
 			       NSEC_PER_SEC / INITIATIONS_PER_SECOND >
 		       (s64)ktime_get_coarse_boottime_ns();
-	up_read(&handshake->lock);
 	if (replay_attack || flood_attack) {
+		up_write(&handshake->lock);
 		WC_DEBUG_PR_CODEPOINT();
 		goto out;
 	}
 
 	/* Success! Copy everything to peer */
-	down_write(&handshake->lock);
 	memcpy(handshake->remote_ephemeral, e, NOISE_PUBLIC_KEY_LEN);
 	if (memcmp(t, handshake->latest_timestamp, NOISE_TIMESTAMP_LEN) > 0)
 		memcpy(handshake->latest_timestamp, t, NOISE_TIMESTAMP_LEN);

--- a/kernel-src/selftest/allowedips.c
+++ b/kernel-src/selftest/allowedips.c
@@ -369,7 +369,7 @@ static __init bool randomized_test(void)
 			mutate_mask[k] = 0xff
 					 << ((8 - (mutate_amount % 8)) % 8);
 			/* 16 bytes of IPv6 address */
-			for (; k < 16; ++k)
+			for (k = mutate_amount/8 + 1; k < 16; ++k)
 				mutate_mask[k] = 0;
 			for (k = 0; k < 16; ++k)
 				mutated[k] = (mutated[k] & mutate_mask[k]) |

--- a/kernel-src/wolfcrypt_glue.c
+++ b/kernel-src/wolfcrypt_glue.c
@@ -763,8 +763,10 @@ int wc_ecc_shared_secret_exim(u8 *secret, size_t secret_len,
         PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_shared_secret(privKey, pubKey, secret, &secret_len_copy);
         PRIVATE_KEY_LOCK();
-        if ((ret == 0) && (secret_len_copy != (word32)secret_len))
+        if ((ret == 0) && (secret_len_copy != (word32)secret_len)) {
             ret = WC_KEY_SIZE_E;
+            wc_ForceZero(secret, secret_len);
+        }
     }
 
 out:

--- a/user-src/config.c
+++ b/user-src/config.c
@@ -541,8 +541,14 @@ bool config_read_line(struct config_ctx *ctx, const char *input)
 	}
 
 	for (size_t i = 0; i < len; ++i) {
-		if (!char_is_space(input[i]))
+		/* Keep only printable non-space ASCII -- discard control
+		 * characters, UTF-8, etc.
+		 */
+		if (((unsigned char)input[i] > ' ') &&
+		    ((unsigned char)input[i] < 0x7f))
+		{
 			line[cleaned_len++] = input[i];
+		}
 	}
 	if (!cleaned_len)
 		goto out;


### PR DESCRIPTION
mitigate F-4300 "TOCTOU race in wg_noise_handshake_consume_initiation corrupts Noise session state via replay".

Fixes for F-4028 F-4029 F-4481 F-4301 F-4482.

partially (but adequately) address F-4681, F-4682, and F-4683.

tested with
```
wolfssl-multi-test.sh ...
'.*wolfguard.*'
quantum-safe-wolfssl-all-crypto-only-noasm-linuxkm-mainline-clang-tidy
quantum-safe-wolfssl-all-crypto-only-noasm-fips-dev-linuxkm-next-clang-tidy
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-kmemleak
linuxkm-6.15-all-cryptonly-quantum-safe-intelasm-LKCAPI-insmod-crypto-fuzzer-ksan
linuxkm-6.15-all-cryptonly-quantum-safe-fips-dev-intelasm-insmod-crypto-fuzzer-ksan
```
